### PR TITLE
Fixed wrong view class for Twig

### DIFF
--- a/.vaseman/entries/documentation/mvc/view-templating.md
+++ b/.vaseman/entries/documentation/mvc/view-templating.md
@@ -370,7 +370,7 @@ class MyTwigHtmlView extends TwigHtmlView
 
 }
 
-$view = new MyBladeHtmlView;
+$view = new MyTwigHtmlView;
 ```
 
 ## How to Use Twig


### PR DESCRIPTION
``` php
$view = new MyBladeHtmlView;
```

should be

``` php
$view = new MyTwigHtmlView
```

Since the text is about extending the TwigHtmlView and not Blade.
